### PR TITLE
Hashed password storage added

### DIFF
--- a/src/webconsole.main.php
+++ b/src/webconsole.main.php
@@ -75,8 +75,13 @@ class WebConsoleRPCServer extends BaseJsonRpcServer {
         if ($user && $password) {
             global $ACCOUNTS;
 
-            if (isset($ACCOUNTS[$user]) && $ACCOUNTS[$user] && strcmp($password, $ACCOUNTS[$user]) == 0)
-                return $user . ':' . $this->password_hash($password);
+            if (isset($ACCOUNTS[$user]) && $ACCOUNTS[$user]) {
+                if (strcmp($password, $ACCOUNTS[$user]) == 0)
+                    return $user . ':' . $this->password_hash($password);
+                $password = $this->password_hash($password);
+                if (strcmp($password, $ACCOUNTS[$user]) == 0)
+                    return $user . ':' . $this->password_hash($password);
+            }
         }
 
         throw new Exception("Incorrect user or password");


### PR DESCRIPTION
I found myself in a position today where I wanted to share the console between coworkers without revealing my password.

This PR allows the user to store the password as a sha256 hash to preserve secrecy

Example. Before:

``` php
$USER = 'dev';
$PASSWORD = 'dev'; // Password available for all with read access to see
```

After:

``` php
$USER = 'dev';
$PASSWORD = 'ef260e9aa3c673af240d17a2660480361a8e081d1ffeca2a5ed0e3219fc18567';
```
